### PR TITLE
Remove `open` button and make titles clickable

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -117,22 +117,10 @@ form {
 	width: 75%;
 }
 
-.link-content, .link-wrapper{
+.link-content{
 	display: inline-block;
 	vertical-align: middle;
 	float: left;
-}
-
-.link-wrapper{
-	width: 25%;
-	text-align: right;
-}
-.link-url{
-	background: #0d3c37;
-	color: #fff;
-	padding: 10px 15px;
-	border-radius: 3px;
-	display: inline-block;
 }
 
 .link-author{
@@ -189,14 +177,7 @@ form {
 		text-align: center;
 	}
 
-	.link-url{
-		width: 100%;
-		text-align: center;
-		display: block;
-		margin-bottom: 10px;
-	}
-
-	.link-content, .link-wrapper{
+	.link-content {
 		display: block;
 		float: none;
 		width: 100%;

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,11 +15,8 @@
 				<li class="link-item">
 					<div class="link-card card--inlist">
 						<div class="link-content">
-							<div>{{ item.title }}</div>
+							<div><a href="{{ item.url }}">{{ item.title }}</a></div>
 							<span class="link-author">added by {{ item.user_id }}</span>
-						</div>
-						<div class="link-wrapper">
-						    <a class="link-url" target="_blank" href="{{ item.url }}">Open</a>
 						</div>
 					</div>
 				</li>


### PR DESCRIPTION
- Removed the open button
- Made the titles clickable
- Removed `_blank` open too. Users don't expect to be opened a new window and with modern browsers this practise is quite annoying. Let the users chose what they want ;) [More](http://stackoverflow.com/questions/946248/when-should-you-use-target-blank-on-your-links)
